### PR TITLE
Fix missing-dependency issue during TypeDoc generation phase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,12 @@ jobs:
         run: |
           cd ../
           npm install
+
+          cd packages/messier-61-graph
+          npm install
+
+          cd ../messier-61-graphql-server
+          npm install
       - name: Install doc dependencies
         run: yarn install
       - name: Build documentation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,12 @@ jobs:
         run: |
           cd ../
           npm install
+
+          cd packages/messier-61-graph
+          npm install
+
+          cd ../messier-61-graphql-server
+          npm install
       - name: Install doc dependencies
         run: yarn install
       - name: Build documentation

--- a/docs/docs/development/ci-cd.md
+++ b/docs/docs/development/ci-cd.md
@@ -66,6 +66,19 @@ The output of both of the 2 steps above will be picked up and pushed to GitHub P
 
 :::
 
+:::caution
+
+The TypeDoc would require each package to have their dependencies installed locally in order for the TypeDoc execution
+to succeed. This means we must `cd` into each packages under [packages][[Messier-61 packages source] and execute
+`npm install`. This has been reflected in our CI/CD scripts. See
+"Install Messier-61 dependencies so that TypeDoc process source files properly" step of our
+[testing script][Messier-61 test CI script]
+
+In general, package source code dependencies (i.e. any dependencies required by packages under `packages`) are not to be
+added to doc dependences (i.e. `doc/package.json`).
+
+:::
+
 Troubleshooting
 ---------------
 
@@ -108,5 +121,7 @@ npm run prettier-watch
 [GitHub Packages]: https://github.com/features/packages
 
 [Messier-61 npm repo]: https://www.npmjs.com/package/@paiondata/messier-61
+[Messier-61 packages source]: https://github.com/paion-data/Messier-61/tree/master/packages
+[Messier-61 test CI script]: https://github.com/paion-data/Messier-61/blob/master/.github/workflows/test.yml
 
 [Prettier]: https://prettier.io/

--- a/docs/scripts/typedoc.js
+++ b/docs/scripts/typedoc.js
@@ -15,33 +15,25 @@
  */
 const TypeDoc = require("typedoc");
 
-async function main() {
-  const app = new TypeDoc.Application();
+const app = new TypeDoc.Application();
 
-  // Ask TypeDoc to load tsconfig.json and typedoc.json files
-  app.options.addReader(new TypeDoc.TSConfigReader());
-  app.options.addReader(new TypeDoc.TypeDocReader());
+app.options.addReader(new TypeDoc.TSConfigReader());
+app.options.addReader(new TypeDoc.TypeDocReader());
 
-  app.bootstrap({
-    // typedoc options
-    entryPoints: ["../packages/"],
-    exclude: "../**/*+(test|env.d|setupTests).*",
-    entryPointStrategy: "expand",
-    tsconfig: "../tsconfig.json",
-    media: "static/img/typedoc",
-  });
+app.bootstrap({
+  entryPoints: ["../packages/"],
+  exclude: "../**/*+(test|env.d|setupTests).*",
+  entryPointStrategy: "expand",
+  tsconfig: "../tsconfig.json",
+  media: "static/img/typedoc",
+});
 
-  const project = app.convert();
+const project = app.convert();
 
-  // Project has converted correctly
-  if (project) {
-    const outputDir = "./build/api";
-
-    // Rendered docs
-    await app.generateDocs(project, outputDir);
-    // Alternatively generate JSON output
-    await app.generateJson(project, outputDir + "/documentation.json");
-  }
+if (!project) {
+  throw new Error(`app.convert() was not successful`); // early return
 }
 
-main().catch(console.error);
+const outputDir = "./build/api";
+app.generateDocs(project, outputDir);
+app.generateJson(project, outputDir + "/documentation.json");

--- a/packages/messier-61-graph/package-lock.json
+++ b/packages/messier-61-graph/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@paion-data/messier-61-graph",
   "version": "0.1.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/d3-force": "^3.0.4",
-        "@types/lodash": "^4.14.191",
         "d3-force": "^3.0.0",
         "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "@types/d3-force": "^3.0.4",
+        "@types/lodash": "^4.14.191"
       },
       "engines": {
         "node": ">=16.0.0 <18.0.0"
@@ -21,12 +23,14 @@
     "node_modules/@types/d3-force": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.4.tgz",
-      "integrity": "sha512-q7xbVLrWcXvSBBEoadowIUJ7sRpS1yvgMWnzHJggFy5cUZBq2HZL5k/pBSm0GdYWS1vs5/EDwMjSKF55PDY4Aw=="
+      "integrity": "sha512-q7xbVLrWcXvSBBEoadowIUJ7sRpS1yvgMWnzHJggFy5cUZBq2HZL5k/pBSm0GdYWS1vs5/EDwMjSKF55PDY4Aw==",
+      "dev": true
     },
     "node_modules/@types/lodash": {
       "version": "4.14.191",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
@@ -66,48 +70,6 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    }
-  },
-  "dependencies": {
-    "@types/d3-force": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.4.tgz",
-      "integrity": "sha512-q7xbVLrWcXvSBBEoadowIUJ7sRpS1yvgMWnzHJggFy5cUZBq2HZL5k/pBSm0GdYWS1vs5/EDwMjSKF55PDY4Aw=="
-    },
-    "@types/lodash": {
-      "version": "4.14.191",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
-    },
-    "d3-dispatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
-    },
-    "d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "requires": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      }
-    },
-    "d3-quadtree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
-    },
-    "d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
-    },
-    "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="

--- a/packages/messier-61-graph/package.json
+++ b/packages/messier-61-graph/package.json
@@ -24,9 +24,11 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@types/d3-force": "^3.0.4",
-    "@types/lodash": "^4.14.191",
     "d3-force": "^3.0.0",
     "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@types/d3-force": "^3.0.4",
+    "@types/lodash": "^4.14.191"
   }
 }


### PR DESCRIPTION
Changelog
---------

### Added

- Added and documented the process to CI/CD such that each sub-package executes `npm install` in order for TypeDoc to pick up the dependencies to generate API doc properly

### Changed

- All `@types/*` dependencies are pushed down as **dev** dependencies, because they are for **compile-time check only**

### Deprecated

### Removed

### Fixed

- Fiexed the following error during TypeDoc generation:

  ```bash
  ../packages/messier-61-graph/graph-visualization/models/Graph.ts:19:20 - error TS7016: Could not find a declaration file for module 'lodash'. 'Messier-61/node_modules/lodash/lodash.js' implicitly has an 'any' type.
    Try `npm i --save-dev @types/lodash` if it exists or add a new declaration (.d.ts) file containing `declare module 'lodash';`

  19 import * as _ from "lodash";
                      ~~~~~~~~
  ```

- Bubbles up TypeDoc error, if any, to the CI build to prevent the error from propagating to production build

### Security

Checklist
---------

* [x] Test
* [x] Self-review
* [x] Documentation
